### PR TITLE
Use a wider regexp pattern

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ function StripFnLoader(source) {
 
     var toStrip = query.strip.join('|');
 
-    var regexPattern = new RegExp('\\n[ \\t]*(' + toStrip + ')\\([^\\);]+\\)[ \\t]*[;\\n]', 'g');
+    var regexPattern = new RegExp('\\n[ \\t]*(' + toStrip + ').*', 'g');
 
     var transformed = source.replace(regexPattern, '\n');
 

--- a/tests/fixtures/app/index.js
+++ b/tests/fixtures/app/index.js
@@ -4,9 +4,11 @@
  */
 
 var makeFoo = function (bar, baz) {
-    // The following 2 lines of code will be stripped with our webpack loader
+    // The following 3 lines of code will be stripped with our webpack loader
     console.log('some debug info');
     debug('better debug info');
+    debug('even better %s' + (true), 'debug info');
     // This code would remain
+    debugger;
     return new Foo(bar, baz);
 };

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -41,11 +41,11 @@ var createWebpackTest = function (done) {
 
         var originalSource = fs.readFileSync(cwd + '/index.js', {encoding: 'utf8'});
         expect(originalSource).to.contain('console.log');
-        expect(originalSource).to.contain('debug');
+        expect(originalSource).to.contain('debug(');
 
         var strippedSource = statsJson.modules[0].source;
         expect(strippedSource).to.not.contain('console.log');
-        expect(strippedSource).to.not.contain('debug');
+        expect(strippedSource).to.not.contain('debug(');
 
         done(err);
     };


### PR DESCRIPTION
See #4, matches `console.log('I have a (parenthesis)');`

Sadly with regexp [is not easy](http://stackoverflow.com/questions/546433) to match brackets inside brackets, so this will strip also:
```js
console.log('hi'); doVeryImportantStuff();
```
so I'm not 100% sure if this is a good change.