### PR TITLE
Fix stripping of statements on the first line and last line

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ function StripFnLoader(source) {
 
     var toStrip = query.strip.join('|');
 
-    var regexPattern = new RegExp('(?:^|\\n)[ \\t]*(' + toStrip + ')\\([^\\);]+\\)[ \\t]*[;\\n]', 'g');
+    var regexPattern = new RegExp('(?:^|\\n)[ \\t]*(' + toStrip + ')\\([^\\);]+\\)[ \\t]*(?:$|[;\\n])', 'g');
 
     var transformed = source.replace(regexPattern, '\n');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ function StripFnLoader(source) {
 
     var toStrip = query.strip.join('|');
 
-    var regexPattern = new RegExp('\\n[ \\t]*(' + toStrip + ')\\([^\\);]+\\)[ \\t]*[;\\n]', 'g');
+    var regexPattern = new RegExp('(?:^|\\n)[ \\t]*(' + toStrip + ')\\([^\\);]+\\)[ \\t]*[;\\n]', 'g');
 
     var transformed = source.replace(regexPattern, '\n');
 

--- a/tests/fixtures/app/index.js
+++ b/tests/fixtures/app/index.js
@@ -1,3 +1,4 @@
+console.log('a console.log on the first line should get stripped');
 /**
  * Copyright 2015, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
@@ -10,3 +11,4 @@ var makeFoo = function (bar, baz) {
     // This code would remain
     return new Foo(bar, baz);
 };
+console.log('a console.log on the last line without a semicolon should get stripped')


### PR DESCRIPTION
This PR adds some console.log statements to demonstrate the issue reported in #9

It also changes the regex to fix the issue.

You can see a visualization of the updates regex [here](http://tinyurl.com/gvgfelk)