### PR TITLE
Extended support for striping function.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,25 +5,25 @@
 
 "use strict";
 
-var loaderUtils = require('loader-utils');
+var loaderUtils = require( 'loader-utils' );
 
-function StripFnLoader(source) {
-    var query = loaderUtils.parseQuery(this.query);
+function StripFnLoader( source ) {
+    var query = loaderUtils.parseQuery( this.query );
 
-    if (!query || !query.strip) return;
+    if ( !query || !query.strip ) return;
 
-    var toStrip = query.strip.join('|');
+    var toStrip = query.strip.join( '|' );
 
-    var regexPattern = new RegExp('(?:^|\\n)[ \\t]*(' + toStrip + ')\\([^\\);]+\\)[ \\t]*(?:$|[;\\n])', 'g');
+    var regexPattern = new RegExp( '(?:^|\\n)[ \\t]*(' + toStrip + ')\\(((\\"[^\\"]*\\")|(\\\'[^\\\']*\\\')|[^\\);])*\\)[ \\t]*(?:$|[;\\n])', 'g' );
 
-    var transformed = source.replace(regexPattern, '\n');
+    var transformed = source.replace( regexPattern, '\n' );
 
-    this.callback(null, transformed);
+    this.callback( null, transformed );
 }
 module.exports = StripFnLoader;
 
 module.exports.loader = function () {
-    return __filename + '?' + [].slice.call(arguments, 0).map(function (fn) {
+    return __filename + '?' + [].slice.call( arguments, 0 ).map( function ( fn ) {
         return 'strip[]=' + fn;
-    }).join(',');
+    } ).join( ',' );
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,25 +5,25 @@
 
 "use strict";
 
-var loaderUtils = require( 'loader-utils' );
+var loaderUtils = require('loader-utils');
 
-function StripFnLoader( source ) {
-    var query = loaderUtils.parseQuery( this.query );
+function StripFnLoader(source) {
+    var query = loaderUtils.parseQuery(this.query);
 
-    if ( !query || !query.strip ) return;
+    if (!query || !query.strip) return;
 
-    var toStrip = query.strip.join( '|' );
+    var toStrip = query.strip.join('|');
 
-    var regexPattern = new RegExp( '(?:^|\\n)[ \\t]*(' + toStrip + ')\\(((\\"[^\\"]*\\")|(\\\'[^\\\']*\\\')|[^\\);]|\\([^\\);]*\\))*\\)[ \\t]*(?:$|[;\\n])', 'g' );
+    var regexPattern = new RegExp('(?:^|\\n)[ \\t]*(' + toStrip + ')\\(((\\"[^\\"]*\\")|(\\\'[^\\\']*\\\')|[^\\);]|\\([^\\);]*\\))*\\)[ \\t]*(?:$|[;\\n])', 'g');
 
-    var transformed = source.replace( regexPattern, '\n' );
+    var transformed = source.replace(regexPattern, '\n');
 
-    this.callback( null, transformed );
+    this.callback(null, transformed);
 }
 module.exports = StripFnLoader;
 
 module.exports.loader = function () {
-    return __filename + '?' + [].slice.call( arguments, 0 ).map( function ( fn ) {
+    return __filename + '?' + [].slice.call(arguments, 0).map(function (fn) {
         return 'strip[]=' + fn;
-    } ).join( ',' );
+    }).join(',');
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ function StripFnLoader( source ) {
 
     var toStrip = query.strip.join( '|' );
 
-    var regexPattern = new RegExp( '(?:^|\\n)[ \\t]*(' + toStrip + ')\\(((\\"[^\\"]*\\")|(\\\'[^\\\']*\\\')|[^\\);])*\\)[ \\t]*(?:$|[;\\n])', 'g' );
+    var regexPattern = new RegExp( '(?:^|\\n)[ \\t]*(' + toStrip + ')\\(((\\"[^\\"]*\\")|(\\\'[^\\\']*\\\')|[^\\);]|\\([^\\);]*\\))*\\)[ \\t]*(?:$|[;\\n])', 'g' );
 
     var transformed = source.replace( regexPattern, '\n' );
 

--- a/tests/fixtures/app/index.js
+++ b/tests/fixtures/app/index.js
@@ -1,19 +1,19 @@
-console.log( 'a console.log on the first line should get stripped' );
+console.log('a console.log on the first line should get stripped');
 /**
  * Copyright 2015, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-var makeFoo = function ( bar, baz ) {
+var makeFoo = function (bar, baz) {
     // The following 2 lines of code will be stripped with our webpack loader
-    var foo = function ( something ) {
+    var foo = function (something) {
         return "foo";
     };
-    console.log( 'some debug info' );
-    debug( 'better debug info' );
-    console.log( 'some' + "debug " + info + '(even closing parenthesis);' );
-    console.log( 'some' + "debug" + foo( info ) + '(even closing parenthesis)' );
+    console.log('some debug info');
+    debug('better debug info');
+    console.log('some' + "debug " + info + '(even closing parenthesis);');
+    console.log('some' + "debug" + foo(info) + '(even closing parenthesis)');
     // This code would remain
-    return new Foo( bar, baz );
+    return new Foo(bar, baz);
 };
-console.log( 'a console.log on the last line without a semicolon should get stripped' )
+console.log('a console.log on the last line without a semicolon should get stripped')

--- a/tests/fixtures/app/index.js
+++ b/tests/fixtures/app/index.js
@@ -1,14 +1,15 @@
-console.log('a console.log on the first line should get stripped');
+console.log( 'a console.log on the first line should get stripped' );
 /**
  * Copyright 2015, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-var makeFoo = function (bar, baz) {
+var makeFoo = function ( bar, baz ) {
     // The following 2 lines of code will be stripped with our webpack loader
-    console.log('some debug info');
-    debug('better debug info');
+    console.log( 'some debug info' );
+    debug( 'better debug info' );
+    console.log( 'some' + "debug " + info + '(even closing parenthesis);' );
     // This code would remain
-    return new Foo(bar, baz);
+    return new Foo( bar, baz );
 };
-console.log('a console.log on the last line without a semicolon should get stripped')
+console.log( 'a console.log on the last line without a semicolon should get stripped' )

--- a/tests/fixtures/app/index.js
+++ b/tests/fixtures/app/index.js
@@ -6,9 +6,13 @@ console.log( 'a console.log on the first line should get stripped' );
 
 var makeFoo = function ( bar, baz ) {
     // The following 2 lines of code will be stripped with our webpack loader
+    var foo = function ( something ) {
+        return "foo";
+    };
     console.log( 'some debug info' );
     debug( 'better debug info' );
     console.log( 'some' + "debug " + info + '(even closing parenthesis);' );
+    console.log( 'some' + "debug" + foo( info ) + '(even closing parenthesis)' );
     // This code would remain
     return new Foo( bar, baz );
 };


### PR DESCRIPTION
Hello, 

I extended support for striping function which could contain strings with closing parentheses inside like :  console.log(' );' ); or simple function calls like : console.log( foo() );  and unit tests.

> This could be a better solution for : https://github.com/yahoo/strip-loader/pull/5 

@Vijar could you review this ? 

Thanks 
